### PR TITLE
Terminate function commands with semicolons

### DIFF
--- a/lib/travis/build/script/dart.rb
+++ b/lib/travis/build/script/dart.rb
@@ -104,13 +104,13 @@ MESSAGE
             if os == 'windows'
               # Define commands; on Windows git bash requires .bat extensions
               # https://github.com/msysgit/msysgit/issues/101
-              sh.raw 'function dart2js() { dart2js.bat "$@" }'
-              sh.raw 'function dartanalyzer() { dartanalyzer.bat "$@" }'
-              sh.raw 'function dartdevc() { dartdevc.bat "$@" }'
-              sh.raw 'function dartdevk() { dartdevk.bat "$@" }'
-              sh.raw 'function dartdoc() { dartdoc.bat "$@" }'
-              sh.raw 'function dartfmt() { dartfmt.bat "$@" }'
-              sh.raw 'function pub() { pub.bat "$@" }'
+              sh.raw 'function dart2js() { dart2js.bat "$@"; }'
+              sh.raw 'function dartanalyzer() { dartanalyzer.bat "$@"; }'
+              sh.raw 'function dartdevc() { dartdevc.bat "$@"; }'
+              sh.raw 'function dartdevk() { dartdevk.bat "$@"; }'
+              sh.raw 'function dartdoc() { dartdoc.bat "$@"; }'
+              sh.raw 'function dartfmt() { dartfmt.bat "$@"; }'
+              sh.raw 'function pub() { pub.bat "$@"; }'
             end
           end
 


### PR DESCRIPTION
Re:

> /c/Users/travis/.travis/job_stages: line 304: syntax error: unexpected end of file

I added this to my .bash_profile:

```
function dart2js() { echo "$@" }
```

And when I opened bash, I got:

> -bash: /Users/dantup/.bash_profile: line 82: syntax error: unexpected end of file

Turns out you either need a semicolon before the closing `}` or you need to split across lines. Like this, the `}` doesn't close the function.